### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 ## Overview
 The Model Context Protocol (MCP) Server enables integration between MCP clients and the Ethora service.
 
+<a href="https://glama.ai/mcp/servers/@dappros/ethora-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dappros/ethora-mcp-server/badge" alt="Ethora Server MCP server" />
+</a>
+
 ## Tools
 
 - Login user


### PR DESCRIPTION
This PR adds a badge for the [Ethora MCP Server](https://glama.ai/mcp/servers/@dappros/ethora-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dappros/ethora-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dappros/ethora-mcp-server/badge" alt="Ethora Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.